### PR TITLE
add provides, replaces, and conflicts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ deb: build
 	-s dir \
 	-t deb \
 	-v $(VERSION) \
+	--provides $(NAME) \
+	--conflicts "$(NAME) (<< $(VERSION))" \
+	--replaces "$(NAME) (<= $(VERSION))" \
 	--deb-no-default-config-files \
 	--depends c-compiler \
 	--description "$(DESCRIPTION)" \


### PR DESCRIPTION
add provides, replaces, and conflicts to force replace or remove older
versions of library50-c.

@dmalan @glennholloway any comments on this one? tested on the IDE that it replaces library50-c v6.0

(inspired by https://www.debian.org/doc/debian-policy/ch-relationships.html#s7.6.2)

```
~/workspace $ dpkg -l | grep library50-c
ii  library50-c                            6-0                                 amd64        CS50 Library for C
~/workspace $ ls -la /usr/include/cs50.h 
-rw-r--r-- 1 root root 4284 Mar 24  2015 /usr/include/cs50.h
~/workspace $ ls -la /usr/lib/libcs50.a 
-rw-r--r-- 1 root root 4276 Mar 24  2015 /usr/lib/libcs50.a
~/workspace $ sudo dpkg -i library50-c_7.0.0_amd64.deb
(Reading database ... 79104 files and directories currently installed.)
Preparing to unpack library50-c_7.0.0_amd64.deb ...
Unpacking library50-c (7.0.0) over (6-0) ...
Setting up library50-c (7.0.0) ...
~/workspace $ ls -la /usr/include/cs50.h                                                                                                    
ls: cannot access /usr/include/cs50.h: No such file or directory
~/workspace $ ls -la /usr/lib/libcs50.a 
ls: cannot access /usr/lib/libcs50.a: No such file or directory
~/workspace $ ls -la /usr/local/include/cs50.h 
-rw-r--r-- 1 root root 5151 Aug  6 07:58 /usr/local/include/cs50.h
~/workspace $ ls -la /usr/local/lib/libcs50.so                                                                                        
-rw-r--r-- 1 root root 13902 Aug  6 07:58 /usr/local/lib/libcs50.so
```