### PR TITLE
Allow single argument to eprintf

### DIFF
--- a/src/cs50.h
+++ b/src/cs50.h
@@ -69,7 +69,7 @@ void eprintf(const char *file, int line, const char *format, ...) __attribute__(
  * Macro that allows function of the same name to be called without specifying caller's
  * file or line number explicitly.
  */
-#define eprintf(format, ...) eprintf(__FILE__, __LINE__, format, __VA_ARGS__)
+#define eprintf(format, ...) eprintf(__FILE__, __LINE__, format, ##__VA_ARGS__)
 
 /**
  * Reads a line of text from standard input and returns the equivalent


### PR DESCRIPTION
    eprintf("There was an error");

currently expands to

    eprintf("program.c", 1, "There was an error",)

which of course is a syntax error.

This is a well-known flaw in C variadic macros. Many compilers have added the `##__VA_ARGS__` syntax which simply removes the preceding comma if there are no variadic arguments.