### PR TITLE
size_t fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DESCRIPTION = CS50 Library for C
 MAINTAINER = CS50 <sysadmins@cs50.harvard.edu>
 NAME = lib50-c
 OLD_NAME = library50-c
-VERSION = 7.0.1
+VERSION = 7.0.2
 
 .PHONY: bash
 bash:

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ Link with `-lcs50`.
 ## Contributors
 
 *   [Chad Sharp](https://github.com/crossroads1112)
+*   [Emrul Hasan Zawad](https://github.com/ehzShelter)
 *   [Ivan Jasenov](https://github.com/IvanJasenov)
 *   [Kareem Zidane](https://github.com/kzidane)

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -280,6 +280,12 @@ static string *strings = NULL;
  */
 string get_string(void)
 {
+    // check whether we have room for another string
+    if (allocations == SIZE_MAX)
+    {
+        return NULL;
+    }
+
     // growable buffer for characters
     string buffer = NULL;
 
@@ -331,7 +337,7 @@ string get_string(void)
         buffer[size++] = c;
     }
 
-    // return NULL if user provided no input
+    // check whether user provided input
     if (size == 0 && c == EOF)
     {
         return NULL;
@@ -396,7 +402,7 @@ static void teardown(void)
     // free library's strings
     if (strings != NULL)
     {
-        for (int i = 0; i < allocations; i++)
+        for (size_t i = 0; i < allocations; i++)
         {
             free(strings[i]);
         }


### PR DESCRIPTION
Using `size_t` instead of `int` now, per https://github.com/cs50/lib50-c/issues/30. Also fixes bug whereby number allocations might exceed capacity of a `size_t`.