### PR TITLE
static variables and ptrs

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -263,12 +263,12 @@ long long (*GetLongLong)(void) = get_long_long;
 /**
  * Number of strings allocated by get_string.
  */
-static size_t allocations = 0;
+static size_t allocations;
 
 /**
  * Array of strings allocated by get_string.
  */
-static string *strings = NULL;
+static string *strings;
 
 /**
  * Reads a line of text from standard input and returns it as


### PR DESCRIPTION
If variable is declared to be static its default value will be set to 0.
If a pointer is set to be static, it will initially point to NULL.