### PR TITLE
Update cs50.c

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -278,7 +278,7 @@ static string *strings = NULL;
  * error or no input whatsoever (i.e., just EOF). Stores string
  * on heap, but library's destructor frees memory on program's exit.
  */
-string get_string(void)
+const string get_string(void)
 {
     // check whether we have room for another string
     if (allocations == SIZE_MAX)


### PR DESCRIPTION
Since get_string acts like a parser for the other functions the "const" or in this case "const char* " return type explicitly tells the student that get_string reads the user's input and that result cannot be changed(by accident) somewhere along the code.