### PR TITLE
free(tmp) and typecast

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -324,13 +324,16 @@ string get_string(void)
             }
 
             // extend buffer's capacity
-            string temp = realloc(buffer, capacity);
+            string temp = (string*)realloc(buffer, capacity);
             if (temp == NULL)
             {
                 free(buffer);
                 return NULL;
             }
+            // sharing a pointee
             buffer = temp;
+            // and free up tmp
+            free(temp);
         }
 
         // append current character to buffer
@@ -355,7 +358,7 @@ string get_string(void)
     }
 
     // minimize buffer
-    string s = realloc(buffer, size + 1);
+    string s = (string*)realloc(buffer, size + 1);
     if (s == NULL)
     {
         free(buffer);
@@ -372,7 +375,9 @@ string get_string(void)
         free(s);
         return NULL;
     }
+    // sharing a pointee
     strings = tmp;
+    free(tmp);
 
     // append string to array
     strings[allocations] = s;

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -324,7 +324,7 @@ string get_string(void)
             }
 
             // extend buffer's capacity
-            string temp = (string*)realloc(buffer, capacity);
+            string temp = (char*)realloc(buffer, capacity);
             if (temp == NULL)
             {
                 free(buffer);
@@ -358,7 +358,7 @@ string get_string(void)
     }
 
     // minimize buffer
-    string s = (string*)realloc(buffer, size + 1);
+    string s = (char*)realloc(buffer, size + 1);
     if (s == NULL)
     {
         free(buffer);


### PR DESCRIPTION
free(tmp) after sharing and since the return type of realloc is void* and string is not a native data type in c, it's just a typedef of our own, 
I think it's a good practice to explicitly cast the return type so the students would pay attention of the return types and how they get passed through.