### PR TITLE
declares Get* as extern to ensure clang insists on linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DESCRIPTION = CS50 Library for C
 MAINTAINER = CS50 <sysadmins@cs50.harvard.edu>
 NAME = lib50-c
 OLD_NAME = library50-c
-VERSION = 7.1.0
+VERSION = 7.1.1
 
 .PHONY: bash
 bash:

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -78,7 +78,7 @@ void eprintf(const char *file, int line, const char *format, ...) __attribute__(
  * returns CHAR_MAX.
  */
 char get_char(void);
-char (*GetChar)(void);
+extern char (*GetChar)(void);
 
 /**
  * Reads a line of text from standard input and returns the equivalent
@@ -87,7 +87,7 @@ char (*GetChar)(void);
  * prompted to retry. If line can't be read, returns DBL_MAX.
  */
 double get_double(void);
-double (*GetDouble)(void);
+extern double (*GetDouble)(void);
 
 /**
  * Reads a line of text from standard input and returns the equivalent
@@ -96,7 +96,7 @@ double (*GetDouble)(void);
  * retry. If line can't be read, returns FLT_MAX.
  */
 float get_float(void);
-float (*GetFloat)(void);
+extern float (*GetFloat)(void);
 
 /**
  * Reads a line of text from standard input and returns it as an
@@ -105,7 +105,7 @@ float (*GetFloat)(void);
  * prompted to retry. If line can't be read, returns INT_MAX.
  */
 int get_int(void);
-int (*GetInt)(void);
+extern int (*GetInt)(void);
 
 /**
  * Reads a line of text from standard input and returns an equivalent
@@ -114,7 +114,7 @@ int (*GetInt)(void);
  * user is prompted to retry. If line can't be read, returns LLONG_MAX.
  */
 long long get_long_long(void);
-long long (*GetLongLong)(void);
+extern long long (*GetLongLong)(void);
 
 /**
  * Reads a line of text from standard input and returns it as
@@ -125,6 +125,6 @@ long long (*GetLongLong)(void);
  * on heap, but library's destructor frees memory on program's exit.
  */
 string get_string(void);
-string (*GetString)(void);
+extern string (*GetString)(void);
 
 #endif


### PR DESCRIPTION
Previously, student could compile coding using `Get*` without `-lcs50`

```
clang foo.c
```

and `clang` wouldn't complain about a missing symbol.

![unnamed](https://cloud.githubusercontent.com/assets/788678/18412024/04286f70-7753-11e6-8998-37d6d12eacbc.png)
