### PR TITLE
reimplemented GetString without garbage collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DESCRIPTION = CS50 Library for C
 MAINTAINER = CS50 <sysadmins@cs50.harvard.edu>
 NAME = lib50-c
 OLD_NAME = library50-c
-VERSION = 7.1.0
+VERSION = 7.1.1
 
 .PHONY: bash
 bash:

--- a/src/cs50.c
+++ b/src/cs50.c
@@ -381,7 +381,90 @@ string get_string(void)
     // return string
     return s;
 }
-string (*GetString)(void) = get_string;
+string GetString(void)
+{
+    // growable buffer for characters
+    string buffer = NULL;
+
+    // capacity of buffer
+    size_t capacity = 0;
+
+    // number of characters actually in buffer
+    size_t size = 0;
+
+    // character read or EOF
+    int c;
+
+    // iteratively get characters from standard input, checking for CR (Mac OS), LF (Linux), and CRLF (Windows)
+    while ((c = fgetc(stdin)) != '\r' && c != '\n' && c != EOF)
+    {
+        // grow buffer if necessary
+        if (size + 1 > capacity)
+        {
+            // initialize capacity to 16 (as reasonable for most inputs) and double thereafter
+            if (capacity == 0)
+            {
+                capacity = 16;
+            }
+            else if (capacity <= (SIZE_MAX / 2))
+            {
+                capacity *= 2;
+            }
+            else if (capacity < SIZE_MAX)
+            {
+                capacity = SIZE_MAX;
+            }
+            else
+            {
+                free(buffer);
+                return NULL;
+            }
+
+            // extend buffer's capacity
+            string temp = realloc(buffer, capacity);
+            if (temp == NULL)
+            {
+                free(buffer);
+                return NULL;
+            }
+            buffer = temp;
+        }
+
+        // append current character to buffer
+        buffer[size++] = c;
+    }
+
+    // check whether user provided input
+    if (size == 0 && c == EOF)
+    {
+        return NULL;
+    }
+
+    // if last character read was CR, try to read LF as well
+    if (c == '\r' && (c = fgetc(stdin)) != '\n')
+    {
+        // return NULL if character can't be pushed back onto standard input
+        if (c != EOF && ungetc(c, stdin) == EOF)
+        {
+            free(buffer);
+            return NULL;
+        }
+    }
+
+    // minimize buffer
+    string s = realloc(buffer, size + 1);
+    if (s == NULL)
+    {
+        free(buffer);
+        return NULL;
+    }
+
+    // terminate string
+    s[size] = '\0';
+
+    // return string
+    return s;
+}
 
 /**
  * Called automatically before execution enters main.

--- a/src/cs50.h
+++ b/src/cs50.h
@@ -125,6 +125,6 @@ long long (*GetLongLong)(void);
  * on heap, but library's destructor frees memory on program's exit.
  */
 string get_string(void);
-string (*GetString)(void);
+string GetString(void);
 
 #endif


### PR DESCRIPTION
Reimplements `GetString` without garbage collection, for backwards-compatibility with CS50x 2016. To be forcibly deprecated in January 2017.