### PR TITLE
left-shift & assign

### DIFF
--- a/src/cs50.c
+++ b/src/cs50.c
@@ -311,7 +311,7 @@ string get_string(void)
             }
             else if (capacity <= (SIZE_MAX / 2))
             {
-                capacity *= 2;
+                capacity <<= 1;
             }
             else if (capacity < SIZE_MAX)
             {


### PR DESCRIPTION
Here I introduce the notion of left-shift and assign operator instead of the over cheesy  `*=` operator for two reasons.
1) Get the students curious to do some research and examples on operators.
2) Get them comfy with not so obvious but very useful arithmetic operations they for sure will benefit from in the upper years.