### PR TITLE
fixes globbing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ hackerrank: build
 
 .PHONY: install
 install: build
-	cp "$(INCLUDE_DIR)/*" /usr/include
-	cp "$(LIB_DIR)/*" /usr/lib
+	cp "$(INCLUDE_DIR)"/* /usr/include
+	cp "$(LIB_DIR)"/* /usr/lib
 
 # TODO: add dependencies
 .PHONY: pacman
 pacman: build
-	rm -f "$(NAME)-$(VERSION)-*.pkg.tar.xz"
+	rm -f "$(NAME)-$(VERSION)-"*.pkg.tar.xz
 	fpm \
 	-C "$(BUILD_DIR)" \
 	-m "$(MAINTAINER)" \
@@ -98,7 +98,7 @@ pacman: build
 # TODO: add dependencies
 .PHONY: rpm
 rpm: build
-	rm -f "$(NAME)-$(VERSION)-*.rpm"
+	rm -f "$(NAME)-$(VERSION)-"*.rpm
 	fpm \
 	-C "$(BUILD_DIR)" \
 	-m "$(MAINTAINER)" \


### PR DESCRIPTION
```
# make install
rm -rf "build"
mkdir -p "build/usr/include" "build/usr/lib" "build/usr/share/man/man3" "build/usr/src"
gcc -c -fPIC -std=c99 -Wall -Werror -o "build/cs50.o" "src/cs50.c"
gcc -o "build/usr/lib/libcs50.so" -shared "build/cs50.o"
rm -f "build/cs50.o"
cp "src/cs50.h" "build/usr/include"
cp "src/cs50.c" "build/usr/src"
cp -r docs/* "build/usr/share/man/man3"
find "build" -type d -exec chmod 0755 {} +
find "build" -type f -exec chmod 0644 {} +
cp "build/usr/include/*" /usr/include
cp: cannot stat ‘build/usr/include/*’: No such file or directory
make: *** [install] Error 1
```

> Bash performs filename expansion on **unquoted** command-line arguments.

http://www.tldp.org/LDP/abs/html/globbingref.html

cc @dmalan @glennholloway 